### PR TITLE
Remove absolute path from util.typ preventing usgae via usage as submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixed
 - Fixed panic because of undefined variable in error path
 - Fixed incorrect handling of `grid.cell`
+- Removed absolute path to assets in [`util.typ`](./src/util.typ)
 
 ---
 

--- a/src/util.typ
+++ b/src/util.typ
@@ -106,7 +106,7 @@
   /// -> str
   kind,
 ) = {
-  let map = toml("/assets/i18n.toml")
+  let map = toml("../assets/i18n.toml")
 
   if kind not in map.en {
     panic("Unknown kind: `" + kind + "`")


### PR DESCRIPTION
Remove the absolute path reference to the assets folder.

Allows usage via local import without errors.
```typst
#import "modules/subpar/src/lib.typ" as subpar
```